### PR TITLE
 Keller nanolevel addition

### DIFF
--- a/src/KellerModbus.cpp
+++ b/src/KellerModbus.cpp
@@ -107,7 +107,6 @@ bool keller::getValues(float &valueP1, float &valueTOB1)
             {
                valueTOB1 = modbus.float32FromFrame(bigEndian, 3);
             } else return false;
-            //return true;
         }
         else return false;
     } else 

--- a/src/KellerModbus.cpp
+++ b/src/KellerModbus.cpp
@@ -77,10 +77,7 @@ long keller::getSerialNumber(void)
 //     else return false;
 // }
 
-// This gets values back from the sensor
-// Uses Keller Process Value Read Range (0x0100) 32bit floating point,
-// which is Same as 0x0000 .. 0x000B but different mapping for accessing data in one cycle (e.g. P1 and TOB1)
-// P1 is in register 0x0100 & TOB1 (Temperature of sensor1) is in 0x0102
+// This returns previously fetched value
 bool keller::getValueLastTempC(float &value)
 {
     value =  _LastTOB1;
@@ -100,6 +97,7 @@ bool keller::getValues(float &valueP1, float &valueTOB1)
     // valueTOB1 = modbus.float32FromRegister(0x03, 0x0102);
     if (Nanolevel_kellerModel == _model ) 
     {
+        // This gets two values, but as seperate messages
         if (modbus.getRegisters(0x03, 0x0002, 2))
         {
             valueP1 = modbus.float32FromFrame(bigEndian, 3);
@@ -109,13 +107,14 @@ bool keller::getValues(float &valueP1, float &valueTOB1)
             } else return false;
         }
         else return false;
-    } else 
+    } else // for all other sensors get two values in one message
     if (modbus.getRegisters(0x03, 0x0100, 4))
     {
         valueP1 = modbus.float32FromFrame(bigEndian, 3);
         valueTOB1 = modbus.float32FromFrame(bigEndian, 7);
     }
     else return false;
+
     _LastTOB1 = valueTOB1;
     return true;
 }

--- a/src/KellerModbus.h
+++ b/src/KellerModbus.h
@@ -1,9 +1,9 @@
 /*
 KellerModbus.h
 
-Written by Anthony Aufdenkampe
+Written by Anthony Aufdenkampe Modified Neil Hancock
 
-Only tested the Acculevel
+Tested with Acculevel, Nanolevel
 - a Keller Series 30, Class 5, Group 20 sensor
 - Software version 5.20-12.28 and later (i.e. made after the 2012 in the 28th week)
 
@@ -20,6 +20,7 @@ Only tested the Acculevel
 typedef enum kellerModel
 {
     Acculevel = 0,
+    Nanolevel_kellerModel = 1,
     OTHER   // Use if the sensor model is another model.
 } kellerModel;
 
@@ -31,8 +32,8 @@ public:
     // This function sets up the communication
     // It should be run during the arduino "setup" function.
     // The "stream" device must be initialized prior to running this.
-    bool begin(byte modbusSlaveID, Stream *stream, int enablePin = -1);
-    bool begin(byte modbusSlaveID, Stream &stream, int enablePin = -1);
+    bool begin(kellerModel model,byte modbusSlaveID, Stream *stream, int enablePin = -1);
+    bool begin(kellerModel model,byte modbusSlaveID, Stream &stream, int enablePin = -1);
 
     // This gets the modbus slave ID.
     // NOTE: NOT YET WORKING
@@ -58,6 +59,7 @@ public:
 
     // This gets values back from the sensor
     bool getValues(float &valueP1, float &valueTOB1);
+    bool getValueLastTempC(float &value);
 //    bool getValues(float &parmValue, float &tempValue, byte &errorCode);
 
     float calcWaterDepthM(float &waterPressureBar, float &waterTempertureC);
@@ -68,8 +70,10 @@ public:
 
 
 private:
-
+    byte _model;
     byte _slaveID;
+    float _LastTOB1;
+
     modbusMaster modbus;
 };
 


### PR DESCRIPTION
Routing for a 2nd Keller device that requires two separate messages to access temperature and water depth.
Follows format of YosemitechParent
Also requires addition in ModularSensors/src/sensors/KellerNanolevel.h  KellerParent.Cpp
