### PR TITLE
Correct dependency specification format

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=A library to use an Arduino as a master to control and communicate via
 category=Sensors
 url=https://github.com/EnviroDIY/KellerModbus
 architectures=avr,sam,samd
-depends=SensorModbusMaster@0.6.8
+depends=SensorModbusMaster


### PR DESCRIPTION
The `depend` field of the [library.properties metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) allows specifying library dependencies, which Library Manager will offer to install along with the library.

There is not currently any support for dependency version control and the attempt to accomplish this resulted in the library releases being rejected by the Library Manager indexer as invalid.